### PR TITLE
fix: cronジョブのCMS出力先をpayloadCMSに変更

### DIFF
--- a/.github/workflows/cron-merge-upstream.yaml
+++ b/.github/workflows/cron-merge-upstream.yaml
@@ -46,7 +46,7 @@ jobs:
     uses: ./.github/workflows/update-masking-quiz.yaml
     needs: merge-upstream
     with:
-      cms_backend: microcms
+      cms_backend: payload
     secrets:
       MICROCMS_API_KEY: ${{ secrets.MICROCMS_API_KEY }}
       MICROCMS_SERVICE_DOMAIN: ${{ secrets.MICROCMS_SERVICE_DOMAIN }}


### PR DESCRIPTION
## 概要

毎日のupstreamマージ後に走る masking quiz 更新ジョブ（`update-masking-quiz.yaml`）の呼び出し時に、`cms_backend` として `microcms` を渡していたため、cron 実行では microCMS が出力先になっていました。本 PR では cron からの出力先を payloadCMS に切り替えます。

## 変更内容

| ファイル | 変更内容 |
| --- | --- |
| `.github/workflows/cron-merge-upstream.yaml` | `update-masking-quiz` ジョブ呼び出しの `cms_backend` を `microcms` → `payload` に変更 |

```diff
     with:
-      cms_backend: microcms
+      cms_backend: payload
```

## 補足

- `workflow_dispatch` 経由の手動実行については、`update-masking-quiz.yaml` 側のデフォルト (`microcms`) と選択肢を維持しているため、引き続き microCMS / payload のいずれも選べます。
- 影響範囲は cron からの自動更新のみで、シークレット類 (`PAYLOAD_API_URL` / `PAYLOAD_API_KEY` など) は既存の設定をそのまま利用します。

## レビューポイント

- payloadCMS 側で cron 実行による上書きが想定どおりかどうか
- 手動実行の挙動を維持できているか（デフォルト `microcms`、選択肢に `payload` あり）

## テスト

- [ ] マージ後、最初の cron 実行（UTC 0:00 / JST 9:00）で payloadCMS にデータが反映されることを確認
- [ ] 必要に応じて `workflow_dispatch` で `cms_backend: payload` を選択し、手動実行で挙動を事前確認

<!-- GitHub Copilot code reviewへの指示: コードレビューの結果は日本語で出力してください。例外はありません。 -->
