### PR TITLE
fix: pip install に click を追加して cron の毎日失敗を解消

### DIFF
--- a/.github/workflows/update-masking-quiz.yaml
+++ b/.github/workflows/update-masking-quiz.yaml
@@ -74,6 +74,7 @@ jobs:
             markdown \
             pygments \
             spacy \
+            click \
             matplotlib \
             numpy \
             pandas \


### PR DESCRIPTION
## 背景

毎日 00:00 UTC の `[Cron] Merge Upstream` ワークフローが `update-masking-quiz / mask-and-upload` ジョブの **Install dependencies** ステップで失敗していた。

失敗ログ（[該当 run](https://github.com/fummicc1/swift-evolution-masking/actions/runs/26669005474/job/78608263756)）:

```
File ".../spacy/cli/_util.py", line 18, in <module>
    from click import NoSuchOption
ModuleNotFoundError: No module named 'click'
```

## 原因

- spacy 3.8系の CLI は `from click import NoSuchOption` のように **click をトップレベルパッケージとして直接 import** している
- しかし spacy は click を直接の依存に宣言しておらず、従来は `typer` が click を一緒に入れてくれることに依存していた
- **typer 0.26.0 以降、typer は click を vendoring（内部取り込み）する方式へ変更**し、click を独立パッケージとしてインストールしなくなった
- このワークフローは依存バージョンをピン留めしていないため、pip が新しい typer 0.26.x を取得した時点で click が入らなくなり、spacy 起動時に毎日失敗するようになった

## 修正

`pip install` のリストに `click` を明示的に追加し、spacy が必要とする click を確実にインストールする。

## 補足

恒久的な再発防止としては、主要依存（spacy / typer / numpy 等）のバージョンピン留めを別途検討する余地がある。