### PR TITLE
chore: GitHub Actions を Node24 ランタイムへ更新（Node20 非推奨対応）

### DIFF
--- a/.github/workflows/cron-merge-upstream.yaml
+++ b/.github/workflows/cron-merge-upstream.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/update-masking-quiz.yaml
+++ b/.github/workflows/update-masking-quiz.yaml
@@ -59,10 +59,10 @@ jobs:
   mask-and-upload:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -97,7 +97,7 @@ jobs:
 
       - name: Store artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: word_freq_hist
           path: artifacts/


### PR DESCRIPTION
## 背景

cron ワークフローで使用しているアクションが **Node.js 20 ランタイム**（一部は Node16）で動作しており、GitHub から Node20 非推奨アラートが出ていた。

## 変更内容

各アクションを **node24 ランタイム**を使用する最新メジャーへ更新:

| アクション | 変更前 | 変更後 | ランタイム |
|---|---|---|---|
| actions/checkout | @v4 / @v3 | **@v6** | node24 |
| actions/setup-python | @v4 | **@v6** | node24 |
| actions/upload-artifact | @v4 | **@v7** | node24 |

## 補足

- GitHub Actions ランナーには **node26 ランタイムが存在しない**（宣言可能なのは node20 / node24 のみ）ため、到達可能な最新である **node24** を採用した
- 各最新版の action.yml が `using: node24` であることを確認済み
- 入力パラメータ（`fetch-depth` / `python-version` / `name` / `path`）は互換性があり、ワークフロー側の追加修正は不要